### PR TITLE
Add Login Action

### DIFF
--- a/login/Dockerfile
+++ b/login/Dockerfile
@@ -1,0 +1,8 @@
+FROM bycedric/ci-expo
+
+LABEL com.github.actions.name="Expo CLI Login"
+LABEL com.github.actions.description="Use Expo CLI in your GitHub Actions workflow."
+LABEL com.github.actions.icon="terminal"
+LABEL com.github.actions.color="gray-dark"
+
+ENTRYPOINT expo login -u $EXPO_USERNAME -p $EXPO_PASSWORD


### PR DESCRIPTION
@byCedric,

Thanks a lot for putting efforts in trying to get actions available for the expo-cli. I've been looking at getting those implemented, but lacked the motivation/knowledge to get started.

During my tests of your action, I've been having lots of problems getting a successful and censored login with the expo-cli. I'm sure you are still working on it as I can see that your docker hub has a few recent changes.

I've come to realise that in order to use the SECRETs without them returning 'Filtered', they need to be use by the `entrypoint.sh` directly and not through arguments. I was inspired by the how the docker/login action works.

The login action in this PR seems to work flawlessly in the different tests I've made, even censoring the SECRET correctly.

Let me know what you think! 

Cheers,